### PR TITLE
Adds missing build dependency liblapacke-dev.

### DIFF
--- a/ubuntu_14.04/dependencies
+++ b/ubuntu_14.04/dependencies
@@ -36,3 +36,4 @@ libopenexr21
 libassimp-dev
 libraptor2-dev
 libgomp1
+liblapacke-dev


### PR DESCRIPTION
This dependency is needed to build PolyVR on Ubuntu 14.04. Note that I did not fix anything for Ubuntu 16.04 since I can't test it.
